### PR TITLE
Add sticky board and remove sidebar user info

### DIFF
--- a/src/app/(app)/dashboard/page.tsx
+++ b/src/app/(app)/dashboard/page.tsx
@@ -3,276 +3,216 @@
 import { useState } from "react";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
-import { Card, CardContent, CardHeader, CardTitle, CardDescription, CardFooter } from "@/components/ui/card";
+import { Card, CardHeader, CardTitle, CardContent } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
+import { Textarea } from "@/components/ui/textarea";
+import { Checkbox } from "@/components/ui/checkbox";
+import { Eraser } from "lucide-react";
 import {
-  ChartContainer,
-  ChartTooltipContent,
-  ChartLegendContent,
-  ChartLegend,
-} from "@/components/ui/chart";
-import { Users, Newspaper, Heart, BarChart as BarChartIcon, Lightbulb, FileText, Target, DollarSign, Loader2 } from "lucide-react";
-import {
-  Bar,
-  Line,
-  Pie,
-  Cell,
-  XAxis,
-  YAxis,
-  CartesianGrid,
-  Tooltip as RechartsTooltip,
-  ResponsiveContainer,
-  AreaChart,
-  Area,
-  PieChart,
-  BarChart,
-} from "recharts";
-import {
-  Dialog,
-  DialogContent,
-  DialogHeader,
-  DialogTitle,
-  DialogDescription,
-  DialogFooter,
-  DialogClose,
-} from "@/components/ui/dialog";
-import { extractInsights, ExtractInsightsOutput } from "@/ai/flows/extract-insights-from-community-data";
-import { useToast } from "@/hooks/use-toast";
-import { ScrollArea } from "@/components/ui/scroll-area";
+  startOfMonth,
+  endOfMonth,
+  startOfWeek,
+  endOfWeek,
+  addDays,
+  isSameDay,
+  format,
+} from "date-fns";
 
+interface Note {
+  id: number;
+  date: Date;
+  color: string;
+  text: string;
+}
 
-const membershipData = [
-  { month: "Jan", new: 4, renewals: 2 },
-  { month: "Feb", new: 3, renewals: 1 },
-  { month: "Mar", new: 5, renewals: 3 },
-  { month: "Apr", new: 7, renewals: 2 },
-  { month: "May", new: 6, renewals: 4 },
-  { month: "Jun", new: 8, renewals: 5 },
-];
+interface Task {
+  id: number;
+  text: string;
+  status: number;
+}
 
-const attendanceData = [
-    { event: 'Spring Gala', tickets: 200, attendance: 180 },
-    { event: 'Art Fair', tickets: 500, attendance: 450 },
-    { event: 'Workshop A', tickets: 50, attendance: 48 },
-    { event: 'Exhibition B', tickets: 150, attendance: 120 },
-    { event: 'Youth Camp', tickets: 75, attendance: 70 },
-];
-
-const socialData = [
-    { platform: 'Instagram', engagement: 40 },
-    { platform: 'Facebook', engagement: 30 },
-    { platform: 'Twitter', engagement: 15 },
-    { platform: 'LinkedIn', engagement: 15 },
-];
-const COLORS = ["hsl(var(--chart-1))", "hsl(var(--chart-2))", "hsl(var(--chart-3))", "hsl(var(--chart-4))"];
+const statuses = ["Not Started", "In Development", "Completed"];
+const colorClasses: Record<string, string> = {
+  yellow: "bg-yellow-200",
+  pink: "bg-pink-200",
+  blue: "bg-blue-200",
+  green: "bg-green-200",
+  orange: "bg-orange-200",
+};
 
 export default function DashboardPage() {
-  const [isReportDialogOpen, setReportDialogOpen] = useState(false);
-  const [report, setReport] = useState<ExtractInsightsOutput | null>(null);
-  const [isGeneratingReport, setIsGeneratingReport] = useState(false);
-  const { toast } = useToast();
+  const [month, setMonth] = useState(new Date());
+  const [notes, setNotes] = useState<Note[]>([]);
+  const [tasks, setTasks] = useState<Task[]>([]);
+  const [noteText, setNoteText] = useState("");
+  const [noteDate, setNoteDate] = useState<Date | undefined>(new Date());
+  const [noteColor, setNoteColor] = useState("yellow");
+  const [taskText, setTaskText] = useState("");
 
-  const handleGenerateReport = async () => {
-    setIsGeneratingReport(true);
-    setReport(null);
-    setReportDialogOpen(true);
+  const days: Date[] = [];
+  for (
+    let day = startOfWeek(startOfMonth(month));
+    day <= endOfWeek(endOfMonth(month));
+    day = addDays(day, 1)
+  ) {
+    days.push(day);
+  }
 
-    const communityData = `
-      **Membership Growth:**
-      ${membershipData.map(d => `${d.month}: ${d.new} new members, ${d.renewals} renewals.`).join('\n')}
+  const weeks: Date[][] = [];
+  for (let i = 0; i < days.length; i += 7) {
+    weeks.push(days.slice(i, i + 7));
+  }
 
-      **Event Attendance:**
-      ${attendanceData.map(d => `${d.event}: ${d.attendance} attended out of ${d.tickets} tickets sold.`).join('\n')}
-
-      **Social Media Engagement:**
-      ${socialData.map(d => `${d.platform}: ${d.engagement}% engagement.`).join('\n')}
-
-      **Key Metrics:**
-      - Total Members: 1,234 (+20.1% from last month)
-      - Upcoming Events: 12 (3 new this week)
-      - Social Engagement: +5.2K impressions (+12% this month)
-    `;
-
-    try {
-      const result = await extractInsights({ communityData });
-      setReport(result);
-    } catch (error) {
-      console.error(error);
-      toast({
-        variant: "destructive",
-        title: "Error Generating Report",
-        description: "There was an issue creating the report. Please try again.",
-      });
-      setReportDialogOpen(false);
-    } finally {
-      setIsGeneratingReport(false);
-    }
+  const addNote = () => {
+    if (!noteDate || !noteText.trim()) return;
+    setNotes([
+      ...notes,
+      { id: Date.now(), date: noteDate, color: noteColor, text: noteText },
+    ]);
+    setNoteText("");
   };
 
+  const removeNote = (id: number) =>
+    setNotes(notes.filter((n) => n.id !== id));
+
+  const addTask = () => {
+    if (!taskText.trim()) return;
+    setTasks([...tasks, { id: Date.now(), text: taskText, status: 0 }]);
+    setTaskText("");
+  };
+
+  const updateTaskStatus = (id: number, status: number) =>
+    setTasks(tasks.map((t) => (t.id === id ? { ...t, status } : t)));
+
+  const eraseAll = () => {
+    setNotes([]);
+    setTasks([]);
+  };
 
   return (
     <div className="flex-1 space-y-4">
       <PageHeader
-        title="Dashboard"
-        description="Your central hub for events, memberships, and social media."
+        title="Sticky Board"
+        description="Organize notes and tasks on a calendar."
       >
-        <Button onClick={handleGenerateReport} disabled={isGeneratingReport}>
-          {isGeneratingReport ? (
-            <Loader2 className="mr-2 h-4 w-4 animate-spin" />
-          ) : (
-            <BarChartIcon className="mr-2 h-4 w-4" />
-          )}
-          Generate Report
+        <Button variant="outline" size="icon" onClick={eraseAll}>
+          <Eraser className="h-4 w-4" />
         </Button>
       </PageHeader>
-      <div className="p-6 md:p-8 pt-0 grid gap-6 sm:grid-cols-1 lg:grid-cols-3">
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Total Members</CardTitle>
-            <Users className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">1,234</div>
-            <p className="text-xs text-muted-foreground">+20.1% from last month</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Upcoming Events</CardTitle>
-            <Newspaper className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">12</div>
-            <p className="text-xs text-muted-foreground">3 new events scheduled this week</p>
-          </CardContent>
-        </Card>
-        <Card>
-          <CardHeader className="flex flex-row items-center justify-between space-y-0 pb-2">
-            <CardTitle className="text-sm font-medium">Social Engagement</CardTitle>
-            <Heart className="h-4 w-4 text-muted-foreground" />
-          </CardHeader>
-          <CardContent>
-            <div className="text-2xl font-bold">+5.2K</div>
-            <p className="text-xs text-muted-foreground">+12% this month</p>
-          </CardContent>
-        </Card>
-      </div>
-      <div className="p-6 md:p-8 pt-0 grid gap-6 md:grid-cols-2 lg:grid-cols-7">
-        <Card className="lg:col-span-4">
+      <div className="p-6 md:p-8 pt-0 grid gap-6 lg:grid-cols-3">
+        <Card className="lg:col-span-2">
           <CardHeader>
-            <CardTitle className="font-headline">Membership Growth</CardTitle>
-            <CardDescription>New sign-ups and renewals over the last 6 months.</CardDescription>
-          </CardHeader>
-          <CardContent className="pl-2">
-            <ChartContainer config={{}} className="h-[300px] w-full">
-                <ResponsiveContainer>
-                    <AreaChart data={membershipData} margin={{ top: 10, right: 30, left: 0, bottom: 0 }}>
-                        <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                        <XAxis dataKey="month" stroke="hsl(var(--muted-foreground))" fontSize={12} tickLine={false} axisLine={false} />
-                        <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} tickLine={false} axisLine={false} />
-                        <RechartsTooltip content={<ChartTooltipContent />} />
-                        <ChartLegend content={<ChartLegendContent />} />
-                        <Area type="monotone" dataKey="new" stackId="1" stroke="hsl(var(--chart-1))" fill="hsl(var(--chart-1))" fillOpacity={0.4} name="New Members" />
-                        <Area type="monotone" dataKey="renewals" stackId="1" stroke="hsl(var(--chart-2))" fill="hsl(var(--chart-2))" fillOpacity={0.4} name="Renewals" />
-                    </AreaChart>
-                </ResponsiveContainer>
-            </ChartContainer>
-          </CardContent>
-        </Card>
-        <Card className="lg:col-span-3">
-          <CardHeader>
-            <CardTitle className="font-headline">Social Media Engagement</CardTitle>
-            <CardDescription>Engagement distribution across platforms.</CardDescription>
+            <CardTitle>Calendar</CardTitle>
           </CardHeader>
           <CardContent>
-            <ChartContainer config={{}} className="h-[300px] w-full">
-              <ResponsiveContainer width="100%" height="100%">
-                  <PieChart>
-                      <RechartsTooltip content={<ChartTooltipContent nameKey="platform" />} />
-                      <Pie data={socialData} dataKey="engagement" nameKey="platform" cx="50%" cy="50%" outerRadius={100} label>
-                      {socialData.map((entry, index) => (
-                          <Cell key={`cell-${index}`} fill={COLORS[index % COLORS.length]} />
-                      ))}
-                      </Pie>
-                      <ChartLegend content={<ChartLegendContent />} />
-                  </PieChart>
-              </ResponsiveContainer>
-            </ChartContainer>
-          </CardContent>
-        </Card>
-        <Card className="lg:col-span-7">
-          <CardHeader>
-            <CardTitle className="font-headline">Event Attendance</CardTitle>
-            <CardDescription>Comparison of tickets sold vs. actual attendance.</CardDescription>
-          </CardHeader>
-          <CardContent>
-          <ChartContainer config={{}} className="h-[300px] w-full">
-                <ResponsiveContainer>
-                    <BarChart data={attendanceData}>
-                        <CartesianGrid strokeDasharray="3 3" vertical={false} />
-                        <XAxis dataKey="event" stroke="hsl(var(--muted-foreground))" fontSize={12} tickLine={false} axisLine={false} />
-                        <YAxis stroke="hsl(var(--muted-foreground))" fontSize={12} tickLine={false} axisLine={false} />
-                        <RechartsTooltip content={<ChartTooltipContent />} cursor={{fill: 'hsl(var(--accent) / 0.2)'}} />
-                        <ChartLegend content={<ChartLegendContent />} />
-                        <Bar dataKey="tickets" fill="hsl(var(--chart-1))" radius={[4, 4, 0, 0]} name="Tickets Sold" />
-                        <Bar dataKey="attendance" fill="hsl(var(--chart-2))" radius={[4, 4, 0, 0]} name="Attendance" />
-                    </BarChart>
-                </ResponsiveContainer>
-            </ChartContainer>
-          </CardContent>
-        </Card>
-      </div>
-
-      <Dialog open={isReportDialogOpen} onOpenChange={setReportDialogOpen}>
-        <DialogContent className="max-w-2xl">
-          <DialogHeader>
-            <DialogTitle>Generated Insights Report</DialogTitle>
-            <DialogDescription>
-              This AI-generated report provides a summary and analysis of your recent activities.
-            </DialogDescription>
-          </DialogHeader>
-          <ScrollArea className="max-h-[60vh] p-4">
-            {isGeneratingReport ? (
-              <div className="flex items-center justify-center h-48">
-                <Loader2 className="h-8 w-8 animate-spin text-primary" />
-              </div>
-            ) : report ? (
-              <div className="space-y-6">
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2 font-headline"><FileText className="h-5 w-5 text-primary"/> Summary</CardTitle>
-                  </CardHeader>
-                  <CardContent><p className="text-muted-foreground">{report.summary}</p></CardContent>
-                </Card>
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2 font-headline"><Target className="h-5 w-5 text-primary"/> Impact Metrics</CardTitle>
-                  </CardHeader>
-                  <CardContent><p className="text-muted-foreground whitespace-pre-wrap">{report.impactMetrics}</p></CardContent>
-                </Card>
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2 font-headline"><Lightbulb className="h-5 w-5 text-primary"/> Key Testimonials</CardTitle>
-                  </CardHeader>
-                  <CardContent><p className="text-muted-foreground whitespace-pre-wrap">{report.keyTestimonials}</p></CardContent>
-                </Card>
-                <Card>
-                  <CardHeader>
-                    <CardTitle className="flex items-center gap-2 font-headline"><DollarSign className="h-5 w-5 text-primary"/> Funding Justification</CardTitle>
-                  </CardHeader>
-                  <CardContent><p className="text-muted-foreground">{report.fundingJustification}</p></CardContent>
-                </Card>
-              </div>
-            ) : null}
-          </ScrollArea>
-          <DialogFooter>
-            <DialogClose asChild>
-              <Button type="button" variant="secondary">
-                Close
+            <div className="mb-4 flex flex-wrap items-center gap-2">
+              {Object.keys(colorClasses).map((c) => (
+                <button
+                  key={c}
+                  className={`h-6 w-6 rounded border ${colorClasses[c]}`}
+                  onClick={() => setNoteColor(c)}
+                />
+              ))}
+              <Input
+                type="date"
+                value={noteDate ? format(noteDate, "yyyy-MM-dd") : ""}
+                onChange={(e) => setNoteDate(new Date(e.target.value))}
+                className="h-8 text-sm px-1 w-32"
+              />
+              <Input
+                value={noteText}
+                onChange={(e) => setNoteText(e.target.value)}
+                placeholder="Note text"
+                className="h-8 text-sm flex-1"
+              />
+              <Button size="sm" onClick={addNote}>
+                Add Note
               </Button>
-            </DialogClose>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
+            </div>
+            <div className="grid grid-cols-7 gap-2 text-xs">
+              {weeks.map((week, i) => (
+                <div key={i} className="contents">
+                  {week.map((day, j) => (
+                    <div key={j} className="relative h-32 border rounded p-1">
+                      <div className="absolute top-1 right-1 text-[10px] text-muted-foreground">
+                        {format(day, "d")}
+                      </div>
+                      {notes
+                        .filter((n) => isSameDay(n.date, day))
+                        .map((n) => (
+                          <div
+                            key={n.id}
+                            className={`mt-4 rounded p-1 text-xs break-words ${colorClasses[n.color]}`}
+                          >
+                            <div className="flex justify-between items-start gap-1">
+                              <span className="flex-1">{n.text}</span>
+                              <button onClick={() => removeNote(n.id)}>
+                                <Eraser className="h-3 w-3" />
+                              </button>
+                            </div>
+                          </div>
+                        ))}
+                    </div>
+                  ))}
+                </div>
+              ))}
+            </div>
+          </CardContent>
+        </Card>
+        <Card>
+          <CardHeader>
+            <CardTitle>To-Do List</CardTitle>
+          </CardHeader>
+          <CardContent>
+            <div className="space-y-2">
+              <div className="flex gap-2">
+                <Input
+                  value={taskText}
+                  onChange={(e) => setTaskText(e.target.value)}
+                  placeholder="New task"
+                  className="h-8 text-sm flex-1"
+                />
+                <Button size="sm" onClick={addTask}>
+                  Add
+                </Button>
+              </div>
+              <div className="mt-4 space-y-2">
+                {tasks.map((task) => (
+                  <div
+                    key={task.id}
+                    className="flex items-center justify-between border-b pb-1"
+                  >
+                    <div className="flex items-center gap-2">
+                      <Checkbox
+                        checked={task.status === 2}
+                        onCheckedChange={(checked) =>
+                          updateTaskStatus(task.id, checked ? 2 : task.status)
+                        }
+                      />
+                      <span className={task.status === 2 ? "line-through" : ""}>
+                        {task.text}
+                      </span>
+                    </div>
+                    <select
+                      value={task.status}
+                      onChange={(e) =>
+                        updateTaskStatus(task.id, Number(e.target.value))
+                      }
+                      className="text-xs border rounded"
+                    >
+                      {statuses.map((s, idx) => (
+                        <option key={idx} value={idx}>
+                          {s}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                ))}
+              </div>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
     </div>
   );
 }

--- a/src/components/app-sidebar.tsx
+++ b/src/components/app-sidebar.tsx
@@ -82,16 +82,6 @@ export default function AppSidebar() {
                   </SidebarMenuButton>
               </SidebarMenuItem>
           </SidebarMenu>
-          <div className="flex items-center gap-3 p-2 group-data-[collapsible=icon]:justify-center group-data-[collapsible=icon]:p-1.5 group-data-[collapsible=icon]:py-2">
-              <Avatar className="h-8 w-8">
-                  <AvatarImage src="https://placehold.co/40x40.png" alt="User" data-ai-hint="person face"/>
-                  <AvatarFallback>U</AvatarFallback>
-              </Avatar>
-              <div className="flex flex-col group-data-[collapsible=icon]:hidden">
-                  <span className="text-sm font-semibold">Gallery Manager</span>
-                  <span className="text-xs text-muted-foreground">manager@kokomoart.org</span>
-              </div>
-          </div>
         </div>
       </SidebarFooter>
     </Sidebar>


### PR DESCRIPTION
## Summary
- simplify sidebar footer and remove user details
- replace dashboard with a sticky-note board that includes a calendar and editable to-do list

## Testing
- `npm run lint` *(fails: prompts for ESLint setup)*
- `npm run typecheck` *(fails: src/app/(app)/assets/page.tsx:273 Declaration or statement expected)*

------
https://chatgpt.com/codex/tasks/task_e_68830d054da48328b752fa3545c1973a