### PR TITLE
Adjust background to white with subtle wallpaper overlay

### DIFF
--- a/src/app/app-body.tsx
+++ b/src/app/app-body.tsx
@@ -30,9 +30,9 @@ export function AppBody({ children }: { children: React.ReactNode }) {
     <body
       className={cn("font-sans antialiased", fontClass)}
       style={{
-        backgroundColor: "#000000",
+        backgroundColor: "#FFFFFF",
         backgroundImage:
-          "linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(/wallpaper-trending.png)",
+          "linear-gradient(rgba(255, 255, 255, 0.85), rgba(255, 255, 255, 0.85)), url(/wallpaper-trending.png)",
         backgroundRepeat: "repeat",
         backgroundSize: "540px 540px",
         backgroundPosition: "center",


### PR DESCRIPTION
## Summary
- set the application body background color to white for a lighter base
- lighten the wallpaper overlay so the background image appears mostly transparent

## Testing
- npm run lint *(fails: command prompts for ESLint configuration and cannot be run non-interactively)*

------
https://chatgpt.com/codex/tasks/task_e_68c8ca31a118832884c28f8033b30e5d