### PR TITLE
Add canvas size presets and cropping controls

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -54,6 +54,7 @@
         "react-day-picker": "^8.10.1",
         "react-dom": "^18.3.1",
         "react-draggable": "^4.5.0",
+        "react-easy-crop": "^5.5.1",
         "react-hook-form": "^7.54.2",
         "react-pdf": "^10.0.1",
         "react-resizable-panels": "^3.0.3",
@@ -8905,6 +8906,12 @@
         "node": ">=0.10.0"
       }
     },
+    "node_modules/normalize-wheel": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/normalize-wheel/-/normalize-wheel-1.0.1.tgz",
+      "integrity": "sha512-1OnlAPZ3zgrk8B91HyRj+eVv+kS5u+Z0SCsak6Xil/kmgEia50ga7zfkumayonZrImffAxPU/5WcyGhzetHNPA==",
+      "license": "BSD-3-Clause"
+    },
     "node_modules/object-assign": {
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -9654,6 +9661,20 @@
       "peerDependencies": {
         "react": ">= 16.3.0",
         "react-dom": ">= 16.3.0"
+      }
+    },
+    "node_modules/react-easy-crop": {
+      "version": "5.5.1",
+      "resolved": "https://registry.npmjs.org/react-easy-crop/-/react-easy-crop-5.5.1.tgz",
+      "integrity": "sha512-8m6lCmfr6cSE9/447iHu+OniJuy7sdFbTqbsYyAXKygXJplvGCLpodujodWQeBGse11nDIgCbMUKbgucIxQWSQ==",
+      "license": "MIT",
+      "dependencies": {
+        "normalize-wheel": "^1.0.1",
+        "tslib": "^2.0.1"
+      },
+      "peerDependencies": {
+        "react": ">=16.4.0",
+        "react-dom": ">=16.4.0"
       }
     },
     "node_modules/react-hook-form": {

--- a/package.json
+++ b/package.json
@@ -58,6 +58,7 @@
     "react-day-picker": "^8.10.1",
     "react-dom": "^18.3.1",
     "react-draggable": "^4.5.0",
+    "react-easy-crop": "^5.5.1",
     "react-hook-form": "^7.54.2",
     "react-pdf": "^10.0.1",
     "react-resizable-panels": "^3.0.3",

--- a/src/app/(app)/assets/page.tsx
+++ b/src/app/(app)/assets/page.tsx
@@ -1,6 +1,6 @@
 'use client';
 
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
 import { Button } from '@/components/ui/button';
 import { Textarea } from '@/components/ui/textarea';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card';
@@ -11,6 +11,15 @@ import { Terminal } from 'lucide-react';
 import { storage } from '@/lib/firebase';
 import { ref, uploadString, getDownloadURL, listAll } from 'firebase/storage';
 import { v4 as uuidv4 } from 'uuid';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
+import { CANVAS_PRESETS, getCanvasPreset, type CanvasPreset } from '@/lib/canvas-presets';
+import { resizeDataUrl } from '@/lib/image-utils';
 
 export default function AssetsPage() {
   const [prompt, setPrompt] = useState('');
@@ -19,6 +28,8 @@ export default function AssetsPage() {
   const [error, setError] = useState<string | null>(null);
   const [galleryImages, setGalleryImages] = useState<string[]>([]);
   const [isLoadingGallery, setIsLoadingGallery] = useState(true);
+  const [selectedSizeId, setSelectedSizeId] = useState<string>(CANVAS_PRESETS[0].id);
+  const selectedPreset = useMemo(() => getCanvasPreset(selectedSizeId), [selectedSizeId]);
 
   const storagePath = 'artful-images/';
 
@@ -61,12 +72,14 @@ export default function AssetsPage() {
     setError(null);
     setGeneratedImageUrl('');
     try {
+      const orientationHint = `The artwork should be composed for a ${selectedPreset.label.toLowerCase()} canvas (${selectedPreset.ratioLabel}, ${selectedPreset.width}x${selectedPreset.height} pixels).`;
+      const finalPrompt = `${prompt.trim()} ${orientationHint}`.trim();
       const response = await fetch('/api/assets', {
         method: 'POST',
         headers: {
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify({ action: 'generateImage', prompt }),
+        body: JSON.stringify({ action: 'generateImage', prompt: finalPrompt }),
       });
 
       if (!response.ok) {
@@ -77,8 +90,18 @@ export default function AssetsPage() {
       const { imageUrl } = await response.json();
       
       if (imageUrl) {
+        let processedImageData = imageUrl;
+        try {
+          processedImageData = await resizeDataUrl(
+            imageUrl,
+            selectedPreset.width,
+            selectedPreset.height,
+          );
+        } catch (resizeError) {
+          console.error('Error resizing generated image:', resizeError);
+        }
         const storageRef = ref(storage, `${storagePath}${uuidv4()}.png`);
-        await uploadString(storageRef, imageUrl, 'data_url');
+        await uploadString(storageRef, processedImageData, 'data_url');
         const downloadUrl = await getDownloadURL(storageRef);
         
         setGeneratedImageUrl(downloadUrl);
@@ -115,6 +138,24 @@ export default function AssetsPage() {
               onChange={(e) => setPrompt(e.target.value)}
               rows={5}
             />
+            <div className="space-y-2">
+              <h4 className="text-sm font-medium">Canvas size</h4>
+              <Select value={selectedSizeId} onValueChange={setSelectedSizeId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a canvas" />
+                </SelectTrigger>
+                <SelectContent>
+                  {CANVAS_PRESETS.map((preset) => (
+                    <SelectItem key={preset.id} value={preset.id}>
+                      {preset.label} • {preset.ratioLabel} ({preset.width}×{preset.height})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {selectedPreset.description} — exports at {selectedPreset.width}×{selectedPreset.height}px.
+              </p>
+            </div>
             <div className="flex flex-wrap gap-2">
               {examplePrompts.map((p) => (
                 <Button key={p} variant="outline" size="sm" onClick={() => setPrompt(p)}>
@@ -132,7 +173,10 @@ export default function AssetsPage() {
                     <AlertDescription>{error}</AlertDescription>
                 </Alert>
             )}
-            <div className="relative w-full aspect-square bg-gray-100 rounded-lg flex items-center justify-center mt-4">
+            <div
+              className="relative w-full bg-gray-100 rounded-lg flex items-center justify-center mt-4 border border-dashed"
+              style={{ aspectRatio: `${selectedPreset.width} / ${selectedPreset.height}` }}
+            >
                 {isLoading && (
                     <div className="flex flex-col items-center gap-2 text-gray-500">
                         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900"></div>
@@ -143,9 +187,9 @@ export default function AssetsPage() {
                     <Image
                         src={generatedImageUrl}
                         alt="Generated art"
-                        layout="fill"
-                        objectFit="contain"
-                        className="rounded-lg"
+                        fill
+                        sizes="(max-width: 768px) 100vw, 50vw"
+                        className="rounded-lg object-contain"
                     />
                 )}
                  {!isLoading && !generatedImageUrl && (

--- a/src/app/(app)/scribble-diffusion/page.tsx
+++ b/src/app/(app)/scribble-diffusion/page.tsx
@@ -12,6 +12,8 @@ import { v4 as uuidv4 } from 'uuid';
 import Image from 'next/image';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Terminal } from 'lucide-react';
+import { CANVAS_PRESETS, type CanvasPreset } from '@/lib/canvas-presets';
+import { resizeDataUrl } from '@/lib/image-utils';
 
 export default function ScribbleDiffusionPage() {
   const [prompt, setPrompt] = useState('');
@@ -21,6 +23,7 @@ export default function ScribbleDiffusionPage() {
   const [error, setError] = useState<string | null>(null);
   const [galleryImages, setGalleryImages] = useState<string[]>([]);
   const [isLoadingGallery, setIsLoadingGallery] = useState(true);
+  const [canvasPreset, setCanvasPreset] = useState<CanvasPreset>(CANVAS_PRESETS[0]);
 
   const storagePath = 'scribble-diffusion-images/';
 
@@ -76,7 +79,8 @@ export default function ScribbleDiffusionPage() {
       }
 
       const { description } = await describeResponse.json();
-      const finalPrompt = `${prompt}. The image should incorporate elements or the style from this drawing: ${description}`;
+      const orientationHint = `The artwork should be composed for a ${canvasPreset.label.toLowerCase()} canvas (${canvasPreset.ratioLabel}, ${canvasPreset.width}x${canvasPreset.height} pixels).`;
+      const finalPrompt = `${prompt}. The image should incorporate elements or the style from this drawing: ${description}. ${orientationHint}`;
 
       // Step 2: Generate the image with the combined prompt.
       const generateResponse = await fetch('/api/assets', {
@@ -94,11 +98,21 @@ export default function ScribbleDiffusionPage() {
       }
 
       const { imageUrl } = await generateResponse.json();
-      
+
       // Step 3: Upload to storage and update UI.
       if (imageUrl) {
+        let processedImageData = imageUrl;
+        try {
+          processedImageData = await resizeDataUrl(
+            imageUrl,
+            canvasPreset.width,
+            canvasPreset.height,
+          );
+        } catch (resizeError) {
+          console.error('Error resizing generated image:', resizeError);
+        }
         const storageRef = ref(storage, `${storagePath}${uuidv4()}.png`);
-        await uploadString(storageRef, imageUrl, 'data_url');
+        await uploadString(storageRef, processedImageData, 'data_url');
         const downloadUrl = await getDownloadURL(storageRef);
         
         setGeneratedImageUrl(downloadUrl);
@@ -129,7 +143,10 @@ export default function ScribbleDiffusionPage() {
           <CardContent className="space-y-6">
             <div>
               <label className="text-sm font-medium block mb-2">1. Scribble your idea</label>
-              <ScribbleCanvas onScribble={setScribbleDataUrl} />
+              <ScribbleCanvas
+                onScribble={setScribbleDataUrl}
+                onConfigChange={setCanvasPreset}
+              />
             </div>
             <div>
               <label htmlFor="prompt" className="text-sm font-medium block mb-2">2. Describe your vision</label>
@@ -152,7 +169,10 @@ export default function ScribbleDiffusionPage() {
                 </Alert>
             )}
             
-            <div className="relative w-full aspect-video bg-gray-100 rounded-lg flex items-center justify-center mt-4">
+            <div
+              className="relative w-full bg-gray-100 rounded-lg flex items-center justify-center mt-4 border border-dashed"
+              style={{ aspectRatio: `${canvasPreset.width} / ${canvasPreset.height}` }}
+            >
                 {isLoading && (
                     <div className="flex flex-col items-center gap-2 text-gray-500">
                         <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-gray-900"></div>
@@ -163,9 +183,9 @@ export default function ScribbleDiffusionPage() {
                     <Image
                         src={generatedImageUrl}
                         alt="Generated art"
-                        layout="fill"
-                        objectFit="contain"
-                        className="rounded-lg"
+                        fill
+                        sizes="(max-width: 768px) 100vw, 50vw"
+                        className="rounded-lg object-contain"
                     />
                 )}
                  {!isLoading && !generatedImageUrl && (

--- a/src/app/(app)/visualizer/page.tsx
+++ b/src/app/(app)/visualizer/page.tsx
@@ -1,6 +1,6 @@
 "use client";
 
-import { useState } from "react";
+import { useMemo, useState } from "react";
 import { generateCustomArtImages } from "@/ai/flows/generate-custom-art-images";
 import { PageHeader } from "@/components/page-header";
 import { Button } from "@/components/ui/button";
@@ -10,12 +10,23 @@ import { useToast } from "@/hooks/use-toast";
 import { Wand2, Download, Sparkles } from "lucide-react";
 import { Skeleton } from "@/components/ui/skeleton";
 import Image from "next/image";
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from "@/components/ui/select";
+import { CANVAS_PRESETS, getCanvasPreset } from "@/lib/canvas-presets";
+import { resizeDataUrl } from "@/lib/image-utils";
 
 export default function VisualizerPage() {
   const [prompt, setPrompt] = useState("");
   const [imageUrl, setImageUrl] = useState<string | null>(null);
   const [isLoading, setIsLoading] = useState(false);
   const { toast } = useToast();
+  const [selectedSizeId, setSelectedSizeId] = useState<string>(CANVAS_PRESETS[0].id);
+  const selectedPreset = useMemo(() => getCanvasPreset(selectedSizeId), [selectedSizeId]);
 
   async function handleGenerateImage() {
     if (prompt.trim().length < 10) {
@@ -29,8 +40,20 @@ export default function VisualizerPage() {
     setIsLoading(true);
     setImageUrl(null);
     try {
-      const result = await generateCustomArtImages({ prompt });
-      setImageUrl(result.imageUrl);
+      const orientationHint = `The artwork should be composed for a ${selectedPreset.label.toLowerCase()} canvas (${selectedPreset.ratioLabel}, ${selectedPreset.width}x${selectedPreset.height} pixels).`;
+      const finalPrompt = `${prompt.trim()} ${orientationHint}`.trim();
+      const result = await generateCustomArtImages({ prompt: finalPrompt });
+      let finalImageUrl = result.imageUrl;
+      try {
+        finalImageUrl = await resizeDataUrl(
+          result.imageUrl,
+          selectedPreset.width,
+          selectedPreset.height,
+        );
+      } catch (resizeError) {
+        console.error('Error resizing generated image:', resizeError);
+      }
+      setImageUrl(finalImageUrl);
     } catch (error) {
       console.error(error);
       toast({
@@ -49,6 +72,16 @@ export default function VisualizerPage() {
     "A digital illustration of a futuristic art gallery opening.",
     "A whimsical chalk drawing of local landmarks."
   ]
+
+  const handleDownload = () => {
+    if (!imageUrl) return;
+    const link = document.createElement("a");
+    link.href = imageUrl;
+    link.download = `artful-image-${selectedPreset.width}x${selectedPreset.height}.png`;
+    document.body.appendChild(link);
+    link.click();
+    document.body.removeChild(link);
+  };
 
   return (
     <div>
@@ -71,6 +104,24 @@ export default function VisualizerPage() {
               placeholder="e.g., 'A stylized, colorful poster for a jazz music festival in an art gallery, art deco style.'"
               className="min-h-[200px] resize-y"
             />
+            <div className="mt-4 space-y-2">
+              <h4 className="text-sm font-medium">Canvas size</h4>
+              <Select value={selectedSizeId} onValueChange={setSelectedSizeId}>
+                <SelectTrigger>
+                  <SelectValue placeholder="Select a canvas" />
+                </SelectTrigger>
+                <SelectContent>
+                  {CANVAS_PRESETS.map((preset) => (
+                    <SelectItem key={preset.id} value={preset.id}>
+                      {preset.label} • {preset.ratioLabel} ({preset.width}×{preset.height})
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+              <p className="text-xs text-muted-foreground">
+                {selectedPreset.description} — exports at {selectedPreset.width}×{selectedPreset.height}px.
+              </p>
+            </div>
             <div className="mt-4">
               <h4 className="text-sm font-medium mb-2">Creative Suggestions</h4>
               <div className="space-y-2">
@@ -94,19 +145,22 @@ export default function VisualizerPage() {
           <CardHeader>
             <CardTitle className="font-headline">Generated Image</CardTitle>
             <CardDescription>
-              Your AI-generated image will appear here.
+              Sized for a {selectedPreset.label.toLowerCase()} canvas ({selectedPreset.ratioLabel}).
             </CardDescription>
           </CardHeader>
           <CardContent className="flex items-center justify-center">
-            <div className="aspect-square w-full max-w-lg rounded-lg border border-dashed flex items-center justify-center bg-muted/50">
+            <div
+              className="w-full max-w-lg rounded-lg border border-dashed flex items-center justify-center bg-muted/50"
+              style={{ aspectRatio: `${selectedPreset.width} / ${selectedPreset.height}` }}
+            >
               {isLoading ? (
                 <Skeleton className="h-full w-full" />
               ) : imageUrl ? (
                 <Image
                   src={imageUrl}
-                  alt={prompt}
-                  width={512}
-                  height={512}
+                  alt={prompt || 'Generated art'}
+                  width={selectedPreset.width}
+                  height={selectedPreset.height}
                   className="rounded-md object-cover"
                 />
               ) : (
@@ -119,7 +173,11 @@ export default function VisualizerPage() {
             </div>
           </CardContent>
           <CardFooter>
-            <Button variant="outline" disabled={!imageUrl || isLoading}>
+            <Button
+              variant="outline"
+              disabled={!imageUrl || isLoading}
+              onClick={handleDownload}
+            >
               <Download className="mr-2 h-4 w-4" />
               Download
             </Button>

--- a/src/app/app-body.tsx
+++ b/src/app/app-body.tsx
@@ -30,16 +30,26 @@ export function AppBody({ children }: { children: React.ReactNode }) {
     <body
       className={cn("font-sans antialiased", fontClass)}
       style={{
-        backgroundImage: 'url(/wallpaper-trending.png)',
-        backgroundRepeat: 'repeat',
-        backgroundSize: '540px 540px',
-        backgroundPosition: 'center',
-        backgroundAttachment: 'fixed',
-        opacity: 0.15,
-        zIndex: 0,
+        backgroundColor: "#000000",
+        backgroundImage:
+          "linear-gradient(rgba(0, 0, 0, 0.5), rgba(0, 0, 0, 0.5)), url(/wallpaper-trending.png)",
+        backgroundRepeat: "repeat",
+        backgroundSize: "540px 540px",
+        backgroundPosition: "center",
+        backgroundAttachment: "fixed",
       }}
     >
-      <div style={{ position: 'relative', zIndex: 1 }}>
+      <div
+        aria-hidden="true"
+        style={{
+          position: "fixed",
+          inset: 0,
+          backgroundColor: "rgba(255, 255, 255, 0.3)",
+          pointerEvents: "none",
+          zIndex: 0,
+        }}
+      />
+      <div style={{ position: "relative", zIndex: 1 }}>
         <Toaster />
         {children}
       </div>

--- a/src/components/scribble-canvas.tsx
+++ b/src/components/scribble-canvas.tsx
@@ -1,141 +1,326 @@
 'use client';
 
-import React, { useRef, useEffect, useState, useCallback } from 'react';
+import React, { useRef, useEffect, useState, useCallback, useMemo } from 'react';
+import Cropper from 'react-easy-crop';
+import type { Area } from 'react-easy-crop';
 import { Button } from './ui/button';
 import { Slider } from './ui/slider';
 import { Popover, PopoverContent, PopoverTrigger } from './ui/popover';
 import { ChromePicker } from 'react-color';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from './ui/select';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from './ui/dialog';
+import { Label } from './ui/label';
+import { CANVAS_PRESETS, CanvasPreset, getCanvasPreset } from '@/lib/canvas-presets';
+import { cropDataUrl, loadImage, type CropArea } from '@/lib/image-utils';
 
 interface ScribbleCanvasProps {
   onScribble: (dataUrl: string) => void;
+  onConfigChange?: (preset: CanvasPreset) => void;
 }
 
-/**
- * A reusable canvas component for drawing/scribbling.
- * It provides controls for brush color and size, and is responsive.
- * @param onScribble - A callback function that is called with the canvas data URL whenever the user stops drawing.
- */
-const ScribbleCanvas = ({ onScribble }: ScribbleCanvasProps) => {
-  const [backgroundImage, setBackgroundImage] = useState<HTMLImageElement | null>(null);
-  // Handle paste event for images
-  useEffect(() => {
-    const handlePaste = (event: ClipboardEvent) => {
-      if (!canvasRef.current) return;
-      const items = event.clipboardData?.items;
-      if (!items) return;
-      for (let i = 0; i < items.length; i++) {
-        const item = items[i];
-        if (item.type.indexOf('image') !== -1) {
-          const file = item.getAsFile();
-          if (file) {
-            const img = new window.Image();
-            img.onload = () => {
-              setBackgroundImage(img);
-              // Draw image to canvas
-              const ctx = canvasRef.current?.getContext('2d');
-              if (ctx && canvasRef.current) {
-                ctx.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
-                ctx.drawImage(img, 0, 0, canvasRef.current.width, canvasRef.current.height);
-                onScribble(canvasRef.current.toDataURL('image/png'));
-              }
-            };
-            img.src = URL.createObjectURL(file);
-          }
-        }
-      }
-    };
-    window.addEventListener('paste', handlePaste);
-    return () => window.removeEventListener('paste', handlePaste);
-  }, [onScribble]);
-
-  // Redraw background image if set (e.g., after resize)
-  useEffect(() => {
-    if (backgroundImage && canvasRef.current) {
-      const ctx = canvasRef.current.getContext('2d');
-      if (ctx) {
-        ctx.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
-        ctx.drawImage(backgroundImage, 0, 0, canvasRef.current.width, canvasRef.current.height);
-      }
-    }
-  }, [backgroundImage]);
+const ScribbleCanvas = ({ onScribble, onConfigChange }: ScribbleCanvasProps) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
-  const [isDrawing, setIsDrawing] = useState(false);
+  const fileInputRef = useRef<HTMLInputElement | null>(null);
   const [context, setContext] = useState<CanvasRenderingContext2D | null>(null);
+  const [isDrawing, setIsDrawing] = useState(false);
+  const [lastPoint, setLastPoint] = useState<{ x: number; y: number } | null>(null);
+
   const [brushColor, setBrushColor] = useState('#000000');
   const [brushSize, setBrushSize] = useState([5]);
   const [isEraser, setIsEraser] = useState(false);
+  const [calligraphyAngle, setCalligraphyAngle] = useState(45);
 
-  // This function now only handles resizing, not styling.
+  const [selectedPresetId, setSelectedPresetId] = useState<string>(CANVAS_PRESETS[0].id);
+  const selectedPreset = useMemo(
+    () => getCanvasPreset(selectedPresetId),
+    [selectedPresetId],
+  );
+
+  const [backgroundImage, setBackgroundImage] = useState<HTMLImageElement | null>(null);
+  const [originalImageSrc, setOriginalImageSrc] = useState<string | null>(null);
+
+  const [isCropperOpen, setIsCropperOpen] = useState(false);
+  const [cropImageSrc, setCropImageSrc] = useState<string | null>(null);
+  const [cropPosition, setCropPosition] = useState({ x: 0, y: 0 });
+  const [cropZoom, setCropZoom] = useState(1);
+  const [croppedAreaPixels, setCroppedAreaPixels] = useState<CropArea | null>(null);
+
+  useEffect(() => {
+    onConfigChange?.(selectedPreset);
+  }, [onConfigChange, selectedPreset]);
+
+  const applyContextSettings = useCallback(
+    (ctx: CanvasRenderingContext2D) => {
+      if (isEraser) {
+        ctx.globalCompositeOperation = 'destination-out';
+        ctx.strokeStyle = 'rgba(0,0,0,1)';
+      } else {
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.strokeStyle = brushColor;
+      }
+      ctx.lineWidth = brushSize[0];
+      ctx.lineCap = 'round';
+      ctx.lineJoin = 'round';
+    },
+    [brushColor, brushSize, isEraser],
+  );
+
+  const exportCanvasData = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return '';
+    const outputCanvas = document.createElement('canvas');
+    outputCanvas.width = selectedPreset.width;
+    outputCanvas.height = selectedPreset.height;
+    const outputContext = outputCanvas.getContext('2d');
+    if (!outputContext) return '';
+    outputContext.drawImage(canvas, 0, 0, outputCanvas.width, outputCanvas.height);
+    return outputCanvas.toDataURL('image/png');
+  }, [selectedPreset]);
+
+  const notifyScribble = useCallback(() => {
+    const dataUrl = exportCanvasData();
+    if (dataUrl) {
+      onScribble(dataUrl);
+    }
+  }, [exportCanvasData, onScribble]);
+
+  const drawDataUrlToCanvas = useCallback(
+    async (dataUrl: string) => {
+      const canvas = canvasRef.current;
+      if (!canvas) return;
+      const ctx = canvas.getContext('2d');
+      if (!ctx) return;
+
+      const { width: displayWidth, height: displayHeight } = canvas.getBoundingClientRect();
+
+      try {
+        const image = await loadImage(dataUrl);
+        ctx.save();
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.clearRect(0, 0, displayWidth, displayHeight);
+        ctx.drawImage(image, 0, 0, displayWidth, displayHeight);
+        ctx.restore();
+        setBackgroundImage(image);
+        applyContextSettings(ctx);
+        notifyScribble();
+      } catch (error) {
+        console.error('Unable to draw image on canvas', error);
+      }
+    },
+    [applyContextSettings, notifyScribble],
+  );
+
   const resizeCanvas = useCallback(() => {
     const canvas = canvasRef.current;
     if (!canvas || !canvas.parentElement) return;
 
-    // Save current drawing
-    const imageData = canvas.getContext('2d')?.getImageData(0, 0, canvas.width, canvas.height);
-
     const parent = canvas.parentElement;
     const rect = parent.getBoundingClientRect();
+    const displayWidth = rect.width;
+    const displayHeight = rect.width / selectedPreset.aspectRatio;
     const dpr = window.devicePixelRatio || 1;
-    
-    canvas.width = rect.width * dpr;
-    canvas.height = (rect.width * 0.75) * dpr; // 4:3 aspect ratio
-    
+
+    const snapshot =
+      canvas.width > 0 && canvas.height > 0 ? canvas.toDataURL('image/png') : null;
+
+    canvas.style.width = `${displayWidth}px`;
+    canvas.style.height = `${displayHeight}px`;
+    canvas.width = Math.max(1, Math.round(displayWidth * dpr));
+    canvas.height = Math.max(1, Math.round(displayHeight * dpr));
+
     const ctx = canvas.getContext('2d');
-    if (ctx) {
-      ctx.scale(dpr, dpr);
-      // Restore drawing after resize
-      if (imageData) {
-        ctx.putImageData(imageData, 0, 0);
+    if (!ctx) return;
+
+    ctx.setTransform(1, 0, 0, 1, 0, 0);
+    ctx.scale(dpr, dpr);
+    ctx.save();
+    ctx.globalCompositeOperation = 'source-over';
+    ctx.clearRect(0, 0, displayWidth, displayHeight);
+    ctx.restore();
+    applyContextSettings(ctx);
+    setContext(ctx);
+
+    const restore = async () => {
+      if (snapshot) {
+        try {
+          const image = await loadImage(snapshot);
+          ctx.save();
+          ctx.globalCompositeOperation = 'source-over';
+          ctx.clearRect(0, 0, displayWidth, displayHeight);
+          ctx.drawImage(image, 0, 0, displayWidth, displayHeight);
+          ctx.restore();
+          applyContextSettings(ctx);
+          notifyScribble();
+          return;
+        } catch (error) {
+          console.error('Unable to restore canvas content', error);
+        }
       }
-      // Re-apply settings after resize
-      ctx.strokeStyle = brushColor;
-      ctx.lineWidth = brushSize[0];
-      ctx.lineCap = 'round';
-      ctx.lineJoin = 'round';
-    }
-  }, [brushColor, brushSize]); // Keep dependencies to re-apply style on resize
 
-  // Initialize canvas context
-  useEffect(() => {
-    const canvas = canvasRef.current;
-    if (canvas) {
-      const ctx = canvas.getContext('2d');
-      setContext(ctx);
-      // Initial resize and style setup
-      resizeCanvas();
-    }
-  }, [resizeCanvas]);
-
-  // Set up resize listener
-  useEffect(() => {
-    window.addEventListener('resize', resizeCanvas);
-    return () => {
-      window.removeEventListener('resize', resizeCanvas);
+      if (backgroundImage) {
+        ctx.save();
+        ctx.globalCompositeOperation = 'source-over';
+        ctx.drawImage(backgroundImage, 0, 0, displayWidth, displayHeight);
+        ctx.restore();
+        applyContextSettings(ctx);
+        notifyScribble();
+      }
     };
+
+    void restore();
+  }, [applyContextSettings, backgroundImage, notifyScribble, selectedPreset]);
+
+  useEffect(() => {
+    resizeCanvas();
   }, [resizeCanvas]);
 
-  // Update canvas context settings only when brush properties or eraser change
+  useEffect(() => {
+    const handleWindowResize = () => {
+      resizeCanvas();
+    };
+    window.addEventListener('resize', handleWindowResize);
+    return () => window.removeEventListener('resize', handleWindowResize);
+  }, [resizeCanvas]);
+
   useEffect(() => {
     if (context) {
-      if (isEraser) {
-        context.globalCompositeOperation = 'destination-out';
-        context.strokeStyle = 'rgba(0,0,0,1)';
-      } else {
-        context.globalCompositeOperation = 'source-over';
-        context.strokeStyle = brushColor;
-      }
-      context.lineWidth = brushSize[0];
-      context.lineCap = 'round';
-      context.lineJoin = 'round';
+      applyContextSettings(context);
     }
-  }, [brushColor, brushSize, context, isEraser]);
+  }, [applyContextSettings, context]);
 
-  // Gets the mouse/touch coordinates relative to the canvas
+  const readFileAsDataUrl = useCallback(
+    (file: File) =>
+      new Promise<string>((resolve, reject) => {
+        const reader = new FileReader();
+        reader.onload = () => {
+          const result = reader.result;
+          if (typeof result === 'string') {
+            resolve(result);
+          } else {
+            reject(new Error('Unable to read image file'));
+          }
+        };
+        reader.onerror = () => reject(reader.error ?? new Error('Unable to read image file'));
+        reader.readAsDataURL(file);
+      }),
+    [],
+  );
+
+  const openCropper = useCallback((dataUrl: string, trackOriginal = false) => {
+    if (trackOriginal) {
+      setOriginalImageSrc(dataUrl);
+    }
+    setCropImageSrc(dataUrl);
+    setCropPosition({ x: 0, y: 0 });
+    setCropZoom(1);
+    setCroppedAreaPixels(null);
+    setIsCropperOpen(true);
+  }, []);
+
+  const handleImageFile = useCallback(
+    async (file: File) => {
+      try {
+        const dataUrl = await readFileAsDataUrl(file);
+        openCropper(dataUrl, true);
+      } catch (error) {
+        console.error('Unable to load image', error);
+      }
+    },
+    [openCropper, readFileAsDataUrl],
+  );
+
+  useEffect(() => {
+    const handlePaste = (event: ClipboardEvent) => {
+      const items = event.clipboardData?.items;
+      if (!items) return;
+
+      for (let i = 0; i < items.length; i++) {
+        const item = items[i];
+        if (item.type.startsWith('image/')) {
+          const file = item.getAsFile();
+          if (file) {
+            event.preventDefault();
+            void handleImageFile(file);
+            break;
+          }
+        }
+      }
+    };
+
+    window.addEventListener('paste', handlePaste);
+    return () => window.removeEventListener('paste', handlePaste);
+  }, [handleImageFile]);
+
+  const handleCropComplete = useCallback((_croppedArea: Area, croppedPixels: Area) => {
+    setCroppedAreaPixels({
+      width: croppedPixels.width,
+      height: croppedPixels.height,
+      x: croppedPixels.x,
+      y: croppedPixels.y,
+    });
+  }, []);
+
+  const applyCrop = useCallback(async () => {
+    if (!cropImageSrc || !croppedAreaPixels) return;
+    try {
+      const croppedDataUrl = await cropDataUrl(
+        cropImageSrc,
+        croppedAreaPixels,
+        selectedPreset.width,
+        selectedPreset.height,
+      );
+      await drawDataUrlToCanvas(croppedDataUrl);
+      setIsCropperOpen(false);
+      setCropImageSrc(null);
+    } catch (error) {
+      console.error('Unable to crop image', error);
+    }
+  }, [cropImageSrc, croppedAreaPixels, drawDataUrlToCanvas, selectedPreset]);
+
+  const reCropBackground = useCallback(() => {
+    if (originalImageSrc) {
+      openCropper(originalImageSrc, false);
+    }
+  }, [openCropper, originalImageSrc]);
+
+  const clearCanvas = useCallback(() => {
+    const canvas = canvasRef.current;
+    if (!canvas) return;
+    const ctx = canvas.getContext('2d');
+    if (!ctx) return;
+
+    const { width, height } = canvas.getBoundingClientRect();
+    ctx.save();
+    ctx.globalCompositeOperation = 'source-over';
+    ctx.clearRect(0, 0, width, height);
+    ctx.restore();
+    applyContextSettings(ctx);
+    setBackgroundImage(null);
+    setOriginalImageSrc(null);
+    setLastPoint(null);
+    setIsDrawing(false);
+    onScribble('');
+  }, [applyContextSettings, onScribble]);
+
   const getCoords = (event: React.MouseEvent | React.TouchEvent) => {
     const canvas = canvasRef.current;
     if (!canvas) return { x: 0, y: 0 };
     const rect = canvas.getBoundingClientRect();
-    let clientX, clientY;
+    let clientX: number;
+    let clientY: number;
+
     if ('touches' in event) {
       clientX = event.touches[0].clientX;
       clientY = event.touches[0].clientY;
@@ -143,33 +328,27 @@ const ScribbleCanvas = ({ onScribble }: ScribbleCanvasProps) => {
       clientX = event.clientX;
       clientY = event.clientY;
     }
+
     return {
       x: clientX - rect.left,
       y: clientY - rect.top,
     };
   };
 
-
-  // Calligraphy pen state
-  const [lastPoint, setLastPoint] = useState<{x: number, y: number} | null>(null);
-  const [calligraphyAngle, setCalligraphyAngle] = useState(45); // degrees
-
-  // Event handler to start drawing (calligraphy effect)
   const startDrawing = (event: React.MouseEvent | React.TouchEvent) => {
-    if (context) {
-      const { x, y } = getCoords(event);
-      setLastPoint({ x, y });
-      setIsDrawing(true);
-    }
+    if (!context) return;
+    const { x, y } = getCoords(event);
+    setLastPoint({ x, y });
+    setIsDrawing(true);
   };
 
-  // Event handler for drawing (calligraphy effect)
   const draw = (event: React.MouseEvent | React.TouchEvent) => {
     if (!isDrawing || !context) return;
-    if (event.cancelable) event.preventDefault();
+    if (event.cancelable) {
+      event.preventDefault();
+    }
     const { x, y } = getCoords(event);
     if (lastPoint) {
-      // Calligraphy nib effect: draw a rotated ellipse between lastPoint and (x, y)
       const dx = x - lastPoint.x;
       const dy = y - lastPoint.y;
       const dist = Math.sqrt(dx * dx + dy * dy);
@@ -178,8 +357,8 @@ const ScribbleCanvas = ({ onScribble }: ScribbleCanvasProps) => {
         const t = i / steps;
         const px = lastPoint.x + dx * t;
         const py = lastPoint.y + dy * t;
-        // Add slight irregularity
-        const angle = (calligraphyAngle + (Math.random() - 0.5) * 8) * Math.PI / 180;
+        const angle =
+          (calligraphyAngle + (Math.random() - 0.5) * 8) * (Math.PI / 180);
         const width = brushSize[0] * (0.9 + Math.random() * 0.2);
         const height = width * 0.35 * (0.9 + Math.random() * 0.2);
         context.save();
@@ -188,11 +367,7 @@ const ScribbleCanvas = ({ onScribble }: ScribbleCanvasProps) => {
         context.beginPath();
         context.ellipse(0, 0, width, height, 0, 0, 2 * Math.PI);
         context.fillStyle = isEraser ? 'rgba(0,0,0,1)' : brushColor;
-        if (isEraser) {
-          context.globalCompositeOperation = 'destination-out';
-        } else {
-          context.globalCompositeOperation = 'source-over';
-        }
+        context.globalCompositeOperation = isEraser ? 'destination-out' : 'source-over';
         context.globalAlpha = 0.85 + Math.random() * 0.15;
         context.fill();
         context.restore();
@@ -201,116 +376,188 @@ const ScribbleCanvas = ({ onScribble }: ScribbleCanvasProps) => {
     setLastPoint({ x, y });
   };
 
-  // Event handler to stop drawing and notify parent component
   const stopDrawing = () => {
+    if (!isDrawing) return;
     setIsDrawing(false);
     setLastPoint(null);
-    if (canvasRef.current) {
-      const dataUrl = canvasRef.current.toDataURL('image/png');
-      onScribble(dataUrl);
-    }
-  };
-
-  // Clears the canvas
-  const clearCanvas = () => {
-    if (context && canvasRef.current) {
-      const canvas = canvasRef.current;
-      const dpr = window.devicePixelRatio || 1;
-      context.clearRect(0, 0, canvas.width / dpr, canvas.height / dpr);
-      onScribble('');
-    }
+    notifyScribble();
   };
 
   return (
-    <div className="flex flex-col items-center gap-4 w-full">
-      <canvas
-        ref={canvasRef}
-        onMouseDown={startDrawing}
-        onMouseMove={draw}
-        onMouseUp={stopDrawing}
-        onMouseLeave={stopDrawing}
-        onTouchStart={startDrawing}
-        onTouchMove={draw}
-        onTouchEnd={stopDrawing}
-        className="border-2 border-gray-300 rounded-lg bg-white w-full cursor-crosshair"
-        style={{ touchAction: 'none' }}
-      />
-      <div className="flex flex-col items-center gap-2 w-full">
-        <div className="text-xs text-gray-500">Paste an image from your clipboard (Ctrl+V or Cmd+V) or upload an image to stage it for editing.</div>
-        <input
-          type="file"
-          accept="image/*"
-          style={{ display: 'none' }}
-          id="scribble-upload-input"
-          onChange={e => {
-            const file = e.target.files?.[0];
-            if (file) {
-              const img = new window.Image();
-              img.onload = () => {
-                setBackgroundImage(img);
-                const ctx = canvasRef.current?.getContext('2d');
-                if (ctx && canvasRef.current) {
-                  ctx.clearRect(0, 0, canvasRef.current.width, canvasRef.current.height);
-                  ctx.drawImage(img, 0, 0, canvasRef.current.width, canvasRef.current.height);
-                  onScribble(canvasRef.current.toDataURL('image/png'));
-                }
-              };
-              img.src = URL.createObjectURL(file);
-            }
-          }}
-        />
-        <Button
-          variant="outline"
-          onClick={() => document.getElementById('scribble-upload-input')?.click()}
-          className="w-full"
-        >
-          Upload Image
-        </Button>
-      </div>
-      <div className="flex flex-wrap items-center justify-center gap-4 w-full">
-        <Popover>
-          <PopoverTrigger asChild>
-            <Button variant={isEraser ? "secondary" : "outline"} disabled={isEraser}>
-              <div className="w-6 h-6 rounded-full border" style={{ backgroundColor: brushColor }}></div>
-              <span className="ml-2">Color</span>
+    <>
+      <div className="flex flex-col items-center gap-4 w-full">
+        <div className="w-full space-y-2">
+          <Label className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+            Canvas size
+          </Label>
+          <Select value={selectedPresetId} onValueChange={setSelectedPresetId}>
+            <SelectTrigger className="w-full">
+              <SelectValue placeholder="Select a canvas" />
+            </SelectTrigger>
+            <SelectContent>
+              {CANVAS_PRESETS.map((preset) => (
+                <SelectItem key={preset.id} value={preset.id}>
+                  {preset.label} • {preset.ratioLabel} ({preset.width}×{preset.height})
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          <p className="text-xs text-muted-foreground">
+            {selectedPreset.description} — exports at {selectedPreset.width}×{selectedPreset.height}px.
+          </p>
+        </div>
+        <div className="w-full">
+          <canvas
+            ref={canvasRef}
+            onMouseDown={startDrawing}
+            onMouseMove={draw}
+            onMouseUp={stopDrawing}
+            onMouseLeave={stopDrawing}
+            onTouchStart={startDrawing}
+            onTouchMove={draw}
+            onTouchEnd={stopDrawing}
+            onTouchCancel={stopDrawing}
+            className="border-2 border-gray-300 rounded-lg bg-white w-full cursor-crosshair"
+            style={{
+              touchAction: 'none',
+              aspectRatio: `${selectedPreset.width} / ${selectedPreset.height}`,
+            }}
+          />
+        </div>
+        <div className="flex flex-col items-center gap-2 w-full">
+          <div className="text-xs text-gray-500 text-center">
+            Paste an image from your clipboard (Ctrl+V or Cmd+V) or upload an image to crop and resize it for your selected canvas.
+          </div>
+          <input
+            type="file"
+            accept="image/*"
+            ref={fileInputRef}
+            className="hidden"
+            onChange={(event) => {
+              const file = event.target.files?.[0];
+              if (file) {
+                void handleImageFile(file);
+                event.target.value = '';
+              }
+            }}
+          />
+          <div className="flex flex-col w-full gap-2 sm:flex-row">
+            <Button
+              variant="outline"
+              onClick={() => fileInputRef.current?.click()}
+              className="w-full"
+            >
+              Upload Image
             </Button>
-          </PopoverTrigger>
-          <PopoverContent className="w-auto p-0">
-             <ChromePicker color={brushColor} onChange={(color) => setBrushColor(color.hex)} />
-          </PopoverContent>
-        </Popover>
-        <div className="flex items-center gap-2 w-48">
+            {originalImageSrc && (
+              <Button
+                variant="outline"
+                onClick={reCropBackground}
+                className="w-full"
+              >
+                Crop / Resize Image
+              </Button>
+            )}
+          </div>
+        </div>
+        <div className="flex flex-wrap items-center justify-center gap-4 w-full">
+          <Popover>
+            <PopoverTrigger asChild>
+              <Button variant={isEraser ? 'secondary' : 'outline'} disabled={isEraser}>
+                <div
+                  className="w-6 h-6 rounded-full border"
+                  style={{ backgroundColor: brushColor }}
+                ></div>
+                <span className="ml-2">Color</span>
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-auto p-0">
+              <ChromePicker color={brushColor} onChange={(color) => setBrushColor(color.hex)} />
+            </PopoverContent>
+          </Popover>
+          <div className="flex items-center gap-2 w-48">
             <span>Size:</span>
             <Slider
-                defaultValue={brushSize}
-                onValueChange={setBrushSize}
-                max={50}
-                min={1}
-                step={1}
+              value={brushSize}
+              onValueChange={setBrushSize}
+              max={50}
+              min={1}
+              step={1}
             />
+          </div>
+          <Button onClick={() => setIsEraser(false)} variant={!isEraser ? 'default' : 'outline'}>
+            Brush
+          </Button>
+          <Button onClick={() => setIsEraser(true)} variant={isEraser ? 'default' : 'outline'}>
+            Eraser
+          </Button>
+          <div className="flex items-center gap-2">
+            <span className="text-xs">Angle:</span>
+            <input
+              type="range"
+              min={0}
+              max={90}
+              value={calligraphyAngle}
+              onChange={(e) => setCalligraphyAngle(Number(e.target.value))}
+            />
+            <span className="text-xs w-6 text-center">{calligraphyAngle}°</span>
+          </div>
+          <Button onClick={clearCanvas} variant="destructive">
+            Clear
+          </Button>
         </div>
-        <Button onClick={() => setIsEraser(false)} variant={!isEraser ? "default" : "outline"}>
-          Brush
-        </Button>
-        <Button onClick={() => setIsEraser(true)} variant={isEraser ? "default" : "outline"}>
-          Eraser
-        </Button>
-        <div className="flex items-center gap-2">
-          <span className="text-xs">Angle:</span>
-          <input
-            type="range"
-            min={0}
-            max={90}
-            value={calligraphyAngle}
-            onChange={e => setCalligraphyAngle(Number(e.target.value))}
-          />
-          <span className="text-xs w-6 text-center">{calligraphyAngle}°</span>
-        </div>
-        <Button onClick={clearCanvas} variant="destructive">
-          Clear
-        </Button>
       </div>
-    </div>
+      <Dialog
+        open={isCropperOpen}
+        onOpenChange={(open) => {
+          setIsCropperOpen(open);
+          if (!open) {
+            setCropImageSrc(null);
+            setCroppedAreaPixels(null);
+          }
+        }}
+      >
+        <DialogContent className="max-w-3xl">
+          <DialogHeader>
+            <DialogTitle>Crop & Resize Image</DialogTitle>
+            <DialogDescription>
+              Adjust the crop to match the {selectedPreset.label.toLowerCase()} canvas ({selectedPreset.ratioLabel}, {selectedPreset.width}×{selectedPreset.height}px).
+            </DialogDescription>
+          </DialogHeader>
+          <div className="relative h-[60vh] w-full bg-muted rounded-md overflow-hidden">
+            {cropImageSrc && (
+              <Cropper
+                image={cropImageSrc}
+                crop={cropPosition}
+                zoom={cropZoom}
+                aspect={selectedPreset.aspectRatio}
+                onCropChange={setCropPosition}
+                onZoomChange={setCropZoom}
+                onCropComplete={handleCropComplete}
+              />
+            )}
+          </div>
+          <div className="pt-4 space-y-2">
+            <Label className="text-sm font-medium">Zoom</Label>
+            <Slider
+              value={[cropZoom]}
+              min={1}
+              max={4}
+              step={0.05}
+              onValueChange={(value) => setCropZoom(value[0])}
+            />
+          </div>
+          <div className="flex justify-end gap-2 pt-4">
+            <Button variant="outline" onClick={() => setIsCropperOpen(false)}>
+              Cancel
+            </Button>
+            <Button onClick={applyCrop} disabled={!croppedAreaPixels}>
+              Apply Crop
+            </Button>
+          </div>
+        </DialogContent>
+      </Dialog>
+    </>
   );
 };
 

--- a/src/lib/canvas-presets.ts
+++ b/src/lib/canvas-presets.ts
@@ -1,0 +1,63 @@
+export interface CanvasPreset {
+  id: string;
+  label: string;
+  ratioLabel: string;
+  aspectRatio: number;
+  width: number;
+  height: number;
+  description: string;
+}
+
+export const CANVAS_PRESETS: CanvasPreset[] = [
+  {
+    id: 'square',
+    label: 'Square',
+    ratioLabel: '1:1',
+    aspectRatio: 1,
+    width: 1080,
+    height: 1080,
+    description: 'Instagram posts, thumbnails, profile art',
+  },
+  {
+    id: 'landscape',
+    label: 'Widescreen',
+    ratioLabel: '16:9',
+    aspectRatio: 16 / 9,
+    width: 1920,
+    height: 1080,
+    description: 'YouTube covers, presentations, hero images',
+  },
+  {
+    id: 'portrait',
+    label: 'Vertical',
+    ratioLabel: '9:16',
+    aspectRatio: 9 / 16,
+    width: 1080,
+    height: 1920,
+    description: 'Stories, Reels, Shorts backgrounds',
+  },
+  {
+    id: 'poster',
+    label: 'Poster',
+    ratioLabel: '4:5',
+    aspectRatio: 4 / 5,
+    width: 1080,
+    height: 1350,
+    description: 'Social ads, featured artwork, flyers',
+  },
+  {
+    id: 'classic',
+    label: 'Classic',
+    ratioLabel: '3:2',
+    aspectRatio: 3 / 2,
+    width: 1500,
+    height: 1000,
+    description: 'Prints, postcards, cover art',
+  },
+];
+
+export function getCanvasPreset(presetId: string): CanvasPreset {
+  return (
+    CANVAS_PRESETS.find((preset) => preset.id === presetId) ?? CANVAS_PRESETS[0]
+  );
+}

--- a/src/lib/image-utils.ts
+++ b/src/lib/image-utils.ts
@@ -1,0 +1,76 @@
+export interface CropArea {
+  width: number;
+  height: number;
+  x: number;
+  y: number;
+}
+
+export function loadImage(src: string): Promise<HTMLImageElement> {
+  return new Promise((resolve, reject) => {
+    const image = new Image();
+    image.crossOrigin = 'anonymous';
+    image.onload = () => resolve(image);
+    image.onerror = (error) => reject(error);
+    image.src = src;
+  });
+}
+
+export async function resizeDataUrl(
+  dataUrl: string,
+  width: number,
+  height: number,
+): Promise<string> {
+  const image = await loadImage(dataUrl);
+  const canvas = document.createElement('canvas');
+  canvas.width = width;
+  canvas.height = height;
+  const context = canvas.getContext('2d');
+  if (!context) {
+    throw new Error('Unable to get 2D context');
+  }
+  context.drawImage(image, 0, 0, width, height);
+  return canvas.toDataURL('image/png');
+}
+
+export async function cropDataUrl(
+  dataUrl: string,
+  cropArea: CropArea,
+  targetWidth: number,
+  targetHeight: number,
+): Promise<string> {
+  const image = await loadImage(dataUrl);
+  const cropCanvas = document.createElement('canvas');
+  const cropWidth = Math.max(1, Math.round(cropArea.width));
+  const cropHeight = Math.max(1, Math.round(cropArea.height));
+  cropCanvas.width = cropWidth;
+  cropCanvas.height = cropHeight;
+  const cropContext = cropCanvas.getContext('2d');
+  if (!cropContext) {
+    throw new Error('Unable to get 2D context');
+  }
+  cropContext.drawImage(
+    image,
+    Math.round(cropArea.x),
+    Math.round(cropArea.y),
+    cropWidth,
+    cropHeight,
+    0,
+    0,
+    cropWidth,
+    cropHeight,
+  );
+
+  if (cropWidth === targetWidth && cropHeight === targetHeight) {
+    return cropCanvas.toDataURL('image/png');
+  }
+
+  const outputCanvas = document.createElement('canvas');
+  outputCanvas.width = targetWidth;
+  outputCanvas.height = targetHeight;
+  const outputContext = outputCanvas.getContext('2d');
+  if (!outputContext) {
+    throw new Error('Unable to get 2D context');
+  }
+  outputContext.drawImage(cropCanvas, 0, 0, targetWidth, targetHeight);
+  return outputCanvas.toDataURL('image/png');
+}


### PR DESCRIPTION
## Summary
- add reusable canvas size presets and image helpers for scaling and cropping uploads
- overhaul the Scribble canvas with selectable aspect ratios plus an image crop/resize workflow
- allow Scribble Diffusion and Artful Images tools to target social-friendly dimensions when generating and downloading artwork

## Testing
- `npm run lint` *(fails: prompts for ESLint configuration)*
- `npm run typecheck`


------
https://chatgpt.com/codex/tasks/task_e_68c8a21f218083289ea8ba1637dd8f25